### PR TITLE
docs: update Pico SDK version to 2.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,19 @@
    ```bash
    mkdir -p ~/.pico-sdk/sdk
    ```
-2. Clone the Pico SDK (release 2.1.1) and initialize submodules:
+2. Clone the Pico SDK (release 2.2.0) and initialize submodules:
    ```bash
    cd ~/.pico-sdk/sdk
-   git clone -b 2.1.1 https://github.com/raspberrypi/pico-sdk.git 2.1.1
-   cd 2.1.1
+   git clone -b 2.2.0 https://github.com/raspberrypi/pico-sdk.git 2.2.0
+   cd 2.2.0
    git submodule update --init
    ```
 3. Set the environment variable pointing to the SDK path:
    ```bash
-   export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.1.1
+   export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.2.0
    ```
 
-After completing these steps, the SDK will be available under `~/.pico-sdk/sdk/2.1.1`.
+After completing these steps, the SDK will be available under `~/.pico-sdk/sdk/2.2.0`.
 
 ## Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -46,23 +46,23 @@ The following is an excerpt from a previous setup guide.
    mkdir -p ~/.pico-sdk/sdk
    ```
 
-2. Download the latest release (2.1.1) from the official Raspberry Pi repository
+2. Download the latest release (2.2.0) from the official Raspberry Pi repository
 
    ```bash
    cd ~/.pico-sdk/sdk
-   git clone -b 2.1.1 https://github.com/raspberrypi/pico-sdk.git 2.1.1
-   cd 2.1.1
+   git clone -b 2.2.0 https://github.com/raspberrypi/pico-sdk.git 2.2.0
+   cd 2.2.0
    git submodule update --init
    ```
 
 3. Set the `PICO_SDK_PATH` environment variable
 
    ```bash
-   export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.1.1
+   export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.2.0
    ```
 
 After verifying that the repository was cloned and its submodules were checked out,
-the pico-sdk will be available under `~/.pico-sdk/sdk/2.1.1`.
+the pico-sdk will be available under `~/.pico-sdk/sdk/2.2.0`.
 
 ## Build Instructions
 


### PR DESCRIPTION
## Summary
- update environment instructions to download pico-sdk 2.2.0
- refresh README with new pico-sdk version

## Testing
- `npx --yes editorconfig-checker`
- `cmake -E env PICO_SDK_FETCH_FROM_GIT=1 PICO_SDK_FETCH_FROM_GIT_TAG=2.2.0 cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b28a5526e48324b910619408a134cb