### PR TITLE
Ensure WireGuard artifacts are generated before compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,3 +124,4 @@ target_link_libraries(pico_mcp
 pico_add_extra_outputs(pico_mcp)
 
 include(gen_wireguard_artifacts.cmake)
+add_dependencies(pico_mcp wireguard_artifacts)

--- a/gen_wireguard_artifacts.cmake
+++ b/gen_wireguard_artifacts.cmake
@@ -5,6 +5,7 @@ set(ARG_DEFS  "${CMAKE_SOURCE_DIR}/argument_definitions.h.in")
 
 add_custom_command(
   OUTPUT
+    "${WG_OUTDIR}/argument_definitions.h"
     "${WG_OUTDIR}/wg0.conf"
     "${WG_OUTDIR}/pico.key" "${WG_OUTDIR}/pico.pub"
     "${WG_OUTDIR}/pc.key"   "${WG_OUTDIR}/pc.pub"
@@ -17,7 +18,9 @@ add_custom_command(
           --pico-tunnel-ip "10.7.0.2"
           --allowed-ips "10.7.0.2/32"
           --require-all 0
-  DEPENDS "${CMAKE_SOURCE_DIR}/tools/gen_wireguard_artifacts.py"
+  DEPENDS
+    "${CMAKE_SOURCE_DIR}/tools/gen_wireguard_artifacts.py"
+    "${ARG_DEFS}"
   VERBATIM
 )
 


### PR DESCRIPTION
## Summary
- add argument_definitions.h to the wireguard artifacts custom command outputs and depend on the template
- make pico_mcp depend on wireguard_artifacts so generation runs before compiling C sources

## Testing
- npx --yes editorconfig-checker@3.3.0 gen_wireguard_artifacts.cmake CMakeLists.txt

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69441304adc083249c4c33116bb62153)