### PR TITLE
Document Linux WireGuard setup and translate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,40 @@
 # MCP for Raspberry Pi Pico W
 
-## 全体構成
+## Overview
 
 ```less
 [ Linux / Windows PC ]
    WireGuard Client
-   トンネルIP: 10.7.0.1
+   Tunnel IP: 10.7.0.1
         |
         |  (WireGuard over UDP, LAN)
         |
 [ Raspberry Pi Pico ]
    wireguard-lwip
-   トンネルIP: 10.7.0.2
+   Tunnel IP: 10.7.0.2
    listen_port: 51820
 ```
 
-## WireGuardの設定(Windows)
+## WireGuard Configuration (Windows)
 
-Windowsの場合は下記のURLからWireGuardをインストールします。
+Install WireGuard for Windows from <https://www.wireguard.com/install/>.
 
-<https://www.wireguard.com/install/>
+### Generate the Pico keys
 
-### Pico側のキーの作成
+Run in PowerShell:
 
 ```PowerShell
 wg.exe genkey | Tee-Object pico.key | wg.exe pubkey > pico.pub
 ```
 
-### Windows側の設定
+### Configure Windows
 
-1. WireGuard を起動
+1. Launch WireGuard.
+2. Choose **Add Tunnel** → **Add empty tunnel**.
+3. A key pair is generated automatically; use those values for the PC peer.
 
-2. 「トンネルを追加」→「空のトンネルを追加」
-
-3. 自動的に鍵が生成されます
-
-公開鍵を<pc.pub>とし、PrivateKeyを<pc.key>とします。
-
-設定を下記のように書き換えます。
+Treat the generated public key as `<pc.pub>` and the private key as `<pc.key>`,
+then update the tunnel configuration:
 
 ```ini
 [Interface]
@@ -49,27 +46,75 @@ AllowedIPs = 10.7.0.2/32
 Endpoint   = 192.168.1.50:51820
 ```
 
-### Picoのコードの変更
+### Update the Pico firmware configuration
 
-`argument_definitions.h`を編集して、マクロに値を入れます。
+Edit `argument_definitions.h` and set the macros as follows:
 
-|マクロ|値|備考|
-|-|-|-|
-|WG_PRIVATE_KEY|<pico.key>|Pico側の秘密鍵|
-|WG_ADDRESS|10.7.0.2||
-|WG_SUBNET_MASK_IP|255.255.255.255||
-|WG_GATEWAY_IP|0.0.0.0||
-|WG_PUBLIC_KEY|<pc.pub>|PC側の公開鍵|
-|WG_ALLOWED_IP||未使用|
-|WG_ALLOWED_IP_MASK_IP||未使用|
-|WG_ENDPOINT_IP|192.168.1.100|PC側のIPアドレス|
-|WG_ENDPOINT_PORT|51820|PC側のポート|
+| Macro | Value | Notes |
+| - | - | - |
+| WG_PRIVATE_KEY | `<pico.key>` | Pico private key |
+| WG_ADDRESS | `10.7.0.2` |  |
+| WG_SUBNET_MASK_IP | `255.255.255.255` |  |
+| WG_GATEWAY_IP | `0.0.0.0` |  |
+| WG_PUBLIC_KEY | `<pc.pub>` | PC public key |
+| WG_ALLOWED_IP |  | Unused |
+| WG_ALLOWED_IP_MASK_IP |  | Unused |
+| WG_ENDPOINT_IP | `192.168.1.100` | PC IP address |
+| WG_ENDPOINT_PORT | `51820` | PC WireGuard port |
+
+## WireGuard Configuration (Linux)
+
+The steps below use the `wg-quick` helper on Debian/Ubuntu-style systems. Adapt
+package names and service managers as needed for other distributions.
+
+1. Install WireGuard utilities.
+
+   ```bash
+   sudo apt update
+   sudo apt install wireguard wireguard-tools
+   ```
+
+2. Generate key pairs.
+
+   ```bash
+   # Pico key pair (copy `pico.key` and `pico.pub` into your firmware settings)
+   wg genkey | tee pico.key | wg pubkey > pico.pub
+
+   # Linux client key pair
+   wg genkey | tee pc.key | wg pubkey > pc.pub
+   ```
+
+3. Create `/etc/wireguard/wg0.conf` with the following template, replacing
+   the placeholder values to match your network and the Pico firmware values
+   in `argument_definitions.h`:
+
+   ```ini
+   [Interface]
+   PrivateKey = <pc.key>
+   Address    = 10.7.0.1/32
+
+   [Peer]
+   PublicKey  = <pico.pub>
+   AllowedIPs = 10.7.0.2/32
+   Endpoint   = 192.168.1.50:51820
+   ```
+
+4. Bring up the interface and enable it on boot:
+
+   ```bash
+   sudo wg-quick up wg0
+   sudo systemctl enable wg-quick@wg0
+   ```
+
+Use `sudo wg` to verify that the tunnel is established and exchanging
+handshakes.
 
 ## LED Control via JSON-RPC
 
-The firmware exposes JSON-RPC tools that can be invoked using the `tools/call` method. Use `tools/list` to discover available tools:
-`set_location`, `set_switch_id`, and `set_switch`.
-These allow you to configure the target switch and toggle the onboard LED.
+The firmware exposes JSON-RPC tools that can be invoked using the `tools/call`
+method. Use `tools/list` to discover available tools: `set_location`,
+`set_switch_id`, and `set_switch`. These allow you to configure the target
+switch and toggle the onboard LED.
 
 Example requests:
 
@@ -91,27 +136,27 @@ Example requests:
   "id": 3 }
 ```
 
-Call `set_switch` with `"state": "on"` or `"off"`. The LED changes only when the
-request's `location` or `switch_id` matches the previously set values or when
-both fields are omitted.
+Call `set_switch` with `"state": "on"` or `"off"`. The LED changes only when
+the request's `location` or `switch_id` matches the previously set values or
+when both fields are omitted.
 
 ## How it works
 
-Use the agent mode of Github copilot Chat in Visual Studio Code.
+Use the agent mode of GitHub Copilot Chat in Visual Studio Code.
 
 https://github.com/user-attachments/assets/7c040786-b527-4f8a-829e-545591232b0f
 
 ## Installing the pico-sdk
 
-The following is an excerpt from a previous setup guide.
+The following steps summarize the pico-sdk setup:
 
-1. Create a working directory
+1. Create a working directory.
 
    ```bash
    mkdir -p ~/.pico-sdk/sdk
    ```
 
-2. Download the latest release (2.2.0) from the official Raspberry Pi repository
+2. Download release 2.2.0 from the official Raspberry Pi repository.
 
    ```bash
    cd ~/.pico-sdk/sdk
@@ -120,14 +165,14 @@ The following is an excerpt from a previous setup guide.
    git submodule update --init
    ```
 
-3. Set the `PICO_SDK_PATH` environment variable
+3. Set the `PICO_SDK_PATH` environment variable.
 
    ```bash
    export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.2.0
    ```
 
-After verifying that the repository was cloned and its submodules were checked out,
-the pico-sdk will be available under `~/.pico-sdk/sdk/2.2.0`.
+After verifying that the repository was cloned and its submodules were checked
+out, the pico-sdk will be available under `~/.pico-sdk/sdk/2.2.0`.
 
 ## Build Instructions
 


### PR DESCRIPTION
## Summary
- translate the README to English for consistent documentation
- add Linux WireGuard setup steps alongside existing Windows instructions
- clarify pico-sdk installation summary and existing usage notes

## Testing
- npx --yes editorconfig-checker@3.3.0 README.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469675ca448324913fafd7fb97f7df)